### PR TITLE
Problem: inconvenient readablity of value limits, wrong data types and specification references

### DIFF
--- a/Configuration.md
+++ b/Configuration.md
@@ -521,9 +521,61 @@ Contains system wide settings.
 
 | Property | Type | Existence | Mutablity | Description |
 |-|-|-|-|-|
+| [manufacturer](#core-property-manufacturer) | `string` | Required | Read-only | The name of the WWT device manufacturer. |
+| [modelName](#core-property-modelname) | `string` | Required | Read-only | The model name of the WWT device. |
+| [modelNumber](#core-property-modelnumber) | `string` | Required | Read-only | The model number of the WWT device. |
+| [serialNumber](#core-property-serialnumber) | `string` | Required | Read-only | The serial number of the WWT device. |
 | [country](#core-property-country) | `string` | Required | Writable | The ISO 3361-1 alpha-2 country code the thing is operated in. |
 | [firmware](#core-property-firmware) | `string` | Required | Read-only | The commercial name of a firmware. |
 | [firmwareVersion](#core-property-firmwareversion) | `string` | Required | Read-only | The installed version of the firmware. |
+
+### System property `manufacturer`
+
+The name of the WWT device manufacturer.
+
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
+
+- Must have a length of at least 1 character
+- Must have a length of at most 200 characters
+
+### System property `modelName`
+
+ The model name of the WWT device.
+
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
+
+- Must have a length of at least 1 character
+- Must have a length of at most 200 characters
+
+### System property `modelNumber`
+
+The model number of the WWT device.
+
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
+
+- Must have a length of at least 1 character
+- Must have a length of at most 200 characters
+
+### System property `serialNumber`
+
+The serial number of the WWT device.
+
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
+
+- Must have a length of at least 1 character
+- Must have a length of at most 200 characters
 
 ### System property `country`
 

--- a/Configuration.md
+++ b/Configuration.md
@@ -521,7 +521,7 @@ Contains system wide settings.
 
 | Property | Type | Existence | Mutablity | Description |
 |-|-|-|-|-|
-| [manufacturer](#core-property-manufacturer) | `string` | Required | Read-only | The name of the WWT device manufacturer. |
+| [vendor](#core-property-vendor) | `string` | Required | Read-only | The name of the WWT device vendor. |
 | [modelName](#core-property-modelname) | `string` | Required | Read-only | The model name of the WWT device. |
 | [modelNumber](#core-property-modelnumber) | `string` | Required | Read-only | The model number of the WWT device. |
 | [serialNumber](#core-property-serialnumber) | `string` | Required | Read-only | The serial number of the WWT device. |
@@ -529,9 +529,9 @@ Contains system wide settings.
 | [firmware](#core-property-firmware) | `string` | Required | Read-only | The commercial name of a firmware. |
 | [firmwareVersion](#core-property-firmwareversion) | `string` | Required | Read-only | The installed version of the firmware. |
 
-### System property `manufacturer`
+### System property `vendor`
 
-The name of the WWT device manufacturer.
+The name of the WWT device vendor.
 
 Type: `string`  
 Existence: Required  

--- a/Configuration.md
+++ b/Configuration.md
@@ -32,222 +32,221 @@ The core properties available in the root object.
 
 ### Core property `ais`
 
-A list of installed AI's.
+A list of installed AI's.  
 
-Type: `array` of `object` [AI](#ai-object)
-Existence: Optional
-Mutability: Read-only
-Constraints:
+Type: `array` of `object` [AI](#ai-object)  
+Existence: Optional  
+Mutability: Read-only  
+Constraints:  
 
 - Must not be present if empty
 - Must not be null
 
 ### Core property `bluetooth`
 
-Bluetooth related configuration properties.
+Bluetooth related configuration properties.  
 
-Type: `object` [Bluetooth](#bluetooth-object)
-Existence: Optional
-Mutability: Read-only
-Constraints:
+Type: `object` [Bluetooth](#bluetooth-object)  
+Existence: Optional  
+Mutability: Read-only  
+Constraints:  
 
 - Must not be present if the thing does not support Bluetooth
 - Must be present if the thing supports Bluetooth
 
 ### Core property `ethernet`
 
-Ethernet related configuration properties.
+Ethernet related configuration properties.  
 
-Type: `object` [Ethernet](#ethernet-object)
-Existence: Optional
-Mutability: Read-only
-Constraints:
+Type: `object` [Ethernet](#ethernet-object)  
+Existence: Optional  
+Mutability: Read-only  
+Constraints:  
 
 - Must not be present if the thing does not support Ethernet
 - Must be present if the thing supports Ethernet
 
 ### Core property `id`
 
-The globally unique id of the thing.
+The globally unique id of the thing.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of exactly 5 characters
 
 ### Core property `latitude`
 
-The latitude the thing is installed at.
+The latitude the thing is installed at.  
 
-Type: `number` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `number` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a value between -90 and 90
 
 ### Core property `location`
 
-The name of the location the thing is installed at.
+The name of the location the thing is installed at.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### Core property `locationType`
 
-The type of location the thing is installed at.
+The type of location the thing is installed at.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### Core property `longitude`
 
-The longitude the thing is installed at.
+The longitude the thing is installed at.  
 
-Type: `number` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `number` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a value between -180 and 180
 
 ### Core property `monitored`
 
-The identifier of the monitored object.
+The identifier of the monitored object.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### Core property `monitoredModel`
 
-The commercial model name of the monitored object.
+The commercial model name of the monitored object.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### Core property `monitoredType`
 
-The type of the monitored object.
+The type of the monitored object.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### Core property `mqtt`
 
-MQTT related configuration properties.
+MQTT related configuration properties.  
 
-Type: `object` [MQTT](#mqtt-object)
-Existence: Optional
-Mutability: Read-only
-Constraints:
+Type: `object` [MQTT](#mqtt-object)  
+Existence: Optional  
+Mutability: Read-only  
+Constraints:  
 
 - Must not be present if the thing does not support MQTT
 - Must be present if the thing supports MQTT
 
 ### Core property `name`
 
-A name identifying the thing inside an organization.
+A name identifying the thing inside an organization.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
-
 ### Core property `organization`
 
-The name of the organization the thing is part of.
+The name of the organization the thing is part of.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### Core property `project`
 
-The name of the project the thing is part of.
+The name of the project the thing is part of.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### Core property `sensors`
 
-A list of installed sensors.
+A list of installed sensors.  
 
-Type: `array` of `object` [Sensor](#sensor-object)
-Existence: Optional
-Mutability: Read-only
-Constraints:
+Type: `array` of `object` [Sensor](#sensor-object)  
+Existence: Optional  
+Mutability: Read-only  
+Constraints:  
 
 - Must not be present if empty
 - Must not be null
 
 ### Core property `site`
 
-The name of the site the thing is installed at.
+The name of the site the thing is installed at.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### Core property `system`
 
-Contains system wide settings.
+Contains system wide settings.  
 
-Type: `object` [System](#system-object)
-Existence: Required
-Mutability: Read-only
+Type: `object` [System](#system-object)  
+Existence: Required  
+Mutability: Read-only  
 
 ### Core property `wifi`
 
-WiFi related configuration properties.
+WiFi related configuration properties.  
 
-Type: `object` [WiFi](#wifi-object)
-Existence: Optional
-Mutability: Read-only
-Constraints:
+Type: `object` [WiFi](#wifi-object)  
+Existence: Optional  
+Mutability: Read-only  
+Constraints:  
 
 - Must not be present if the thing does not support WiFi
 - Must be present if the thing supports WiFi
@@ -265,46 +264,46 @@ Configuration properties for an AI.
 
 ### AI property `model`
 
-The commercial model name of the AI.
+The commercial model name of the AI.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### AI property `slot`
 
-The slot the AI is installed in.
+The slot the AI is installed in.  
 
-Type: `integer`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `integer`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must be an unsigned 8 bit integer
 
 ### AI property `training`
 
-A number which denotes a series of cohesive AI trainings. It needs to be unique regarding the system of numbers it resides in.
+A number which denotes a series of cohesive AI trainings. It needs to be unique regarding the system of numbers it resides in.  
 
-Type: `number`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `number`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must be an unsigned 32 bit integer
 
 ### AI property `version`
 
-An AI training version number which starts at 1 and is increased by 1 each time a new training of that AI was done.
+An AI training version number which starts at 1 and is increased by 1 each time a new training of that AI was done.  
 
-Type: `integer`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `integer`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must be an unsigned 32 bit integer
 
@@ -318,12 +317,12 @@ Configuration properties for Bluetooth.
 
 ### Bluetooth property `address`
 
-The identifier unique to every bluetooth thing.
+The identifier unique to every bluetooth thing.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of exactly 17 characters
 
@@ -338,23 +337,23 @@ Configuration properties for Ethernet.
 
 ### Ethernet property `ip`
 
-The IP address assigned to the thing.
+The IP address assigned to the thing.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of exactly 15 characters
 
 ### Ethernet property `mac`
 
-The MAC address of the Ethernet interface.
+The MAC address of the Ethernet interface.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of exactly 17 characters
 
@@ -372,24 +371,24 @@ Configuration properties for MQTT.
 
 ### MQTT property `host`
 
-The IP address or DNS resolvable network name of an MQTT broker.
+The IP address or DNS resolvable network name of an MQTT broker.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### MQTT property `password`
 
-The MQTT broker password.
+The MQTT broker password.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
@@ -397,23 +396,23 @@ Constraints:
 
 ### MQTT property `port`
 
-The MQTT broker port.
+The MQTT broker port.  
 
-Type: `integer` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `integer` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must be an unsigned 16 bit integer
 
 ### MQTT property `username`
 
-The MQTT broker username.
+The MQTT broker username.  
 
-Type: `integer` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `integer` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
@@ -432,43 +431,43 @@ Configuration properties for MQTT messages.
 
 ### MQTT property `hasPayload`
 
-If the MQTT message has a payload.
+If the MQTT message has a payload.  
 
-Type: `boolean`
-Existence: Required
-Mutability: Read-only
+Type: `boolean`  
+Existence: Required  
+Mutability: Read-only  
 
 ### MQTT property `name`
 
-An identifying name of the MQTT message.
+An identifying name of the MQTT message.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 30 characters
 
 ### MQTT property `topic`
 
-The topic of the message.
+The topic of the message.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### MQTT property `toThing`
 
-If the MQTT message is being sent to the thing.
+If the MQTT message is being sent to the thing.  
 
-Type: `boolean`
-Existence: Required
-Mutability: Read-only
+Type: `boolean`  
+Existence: Required  
+Mutability: Read-only  
 
 ## Sensor object
 
@@ -483,35 +482,35 @@ executed. |
 
 ### Sensor property `model`
 
-The commercial model name of the sensor.
+The commercial model name of the sensor.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
 ### Sensor property `port`
 
-The number of the port the sensor is connected to.
+The number of the port the sensor is connected to.  
 
-Type: `integer`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `integer`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must be an unsigned 8 bit integer
 
 ### Sensor property `type`
 
-The type of the sensor.
+The type of the sensor.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
@@ -528,36 +527,36 @@ Contains system wide settings.
 
 ### System property `country`
 
-The ISO 3361-1 alpha-2 country code the thing is operated in.
+The ISO 3361-1 alpha-2 country code the thing is operated in.  
 
-Type: `string`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must consist of two letters
 - Must be one of the [ISO 3361-1 alpha-2 country code](https://www.iso.org/obp/ui)
 
 ### System property `firmware`
 
-The commercial name of a firmware.
+The commercial name of a firmware.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of at least 1 character
 - Must have a length of at most 200 characters
 
 ### System property `firmwareVersion`
 
-The installed version of the firmware.
+The installed version of the firmware.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must adhere to the [semantic versioning](https://semver.org)
 - Must have a length of at least 5 characters
@@ -576,34 +575,34 @@ Configuration properties for WiFi.
 
 ### WiFi property `ip`
 
-The IP address assigned to the thing.
+The IP address assigned to the thing.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of exactly 15 characters
 
 ### WiFi property `mac`
 
-The MAC address of the WiFi interface.
+The MAC address of the WiFi interface.  
 
-Type: `string`
-Existence: Required
-Mutability: Read-only
-Constraints:
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
 
 - Must have a length of exactly 17 characters
 
 ### WiFi property `password`
 
-The password of the WiFi the thing will connect to.
+The password of the WiFi the thing will connect to.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 63 characters
@@ -611,12 +610,12 @@ Constraints:
 
 ### WiFi property `ssid`
 
-The SSID of the WiFi the thing will connect to.
+The SSID of the WiFi the thing will connect to.  
 
-Type: `string` | `null`
-Existence: Required
-Mutability: Writable
-Constraints:
+Type: `string` | `null`  
+Existence: Required  
+Mutability: Writable  
+Constraints:  
 
 - Must have a length of at least 1 characters
 - Must have a length of at most 32 characters

--- a/Configuration.md
+++ b/Configuration.md
@@ -521,13 +521,13 @@ Contains system wide settings.
 
 | Property | Type | Existence | Mutablity | Description |
 |-|-|-|-|-|
-| [vendor](#core-property-vendor) | `string` | Required | Read-only | The name of the WWT device vendor. |
-| [modelName](#core-property-modelname) | `string` | Required | Read-only | The model name of the WWT device. |
-| [modelNumber](#core-property-modelnumber) | `string` | Required | Read-only | The model number of the WWT device. |
-| [serialNumber](#core-property-serialnumber) | `string` | Required | Read-only | The serial number of the WWT device. |
-| [country](#core-property-country) | `string` | Required | Writable | The ISO 3361-1 alpha-2 country code the thing is operated in. |
-| [firmware](#core-property-firmware) | `string` | Required | Read-only | The commercial name of a firmware. |
-| [firmwareVersion](#core-property-firmwareversion) | `string` | Required | Read-only | The installed version of the firmware. |
+| [vendor](#system-property-vendor) | `string` | Required | Read-only | The name of the WWT device vendor. |
+| [modelName](#system-property-modelname) | `string` | Required | Read-only | The model name of the WWT device. |
+| [modelNumber](#system-property-modelnumber) | `string` | Required | Read-only | The model number of the WWT device. |
+| [serialNumber](#system-property-serialnumber) | `string` | Required | Read-only | The serial number of the WWT device. |
+| [country](#system-property-country) | `string` | Required | Writable | The ISO 3361-1 alpha-2 country code the thing is operated in. |
+| [firmware](#system-property-firmware) | `string` | Required | Read-only | The commercial name of a firmware. |
+| [firmwareVersion](#system-property-firmwareversion) | `string` | Required | Read-only | The installed version of the firmware. |
 
 ### System property `vendor`
 

--- a/Configuration.md
+++ b/Configuration.md
@@ -8,27 +8,27 @@ The type of each property is defined in regard to the [JSON Schema](https://json
 
 The core properties available in the root object.
 
-| Property | Type | Existence | Mutablity | Description |
-|-|-|-|-|-|
-| [ais](#core-property-ais) | `array` of `object` [AI](#ai-object) | Optional | Read-only | A list of installed AI's. |
-| [bluetooth](#core-property-bluetooth) | `object` [Bluetooth](#bluetooth-object) | Optional | Read-only | Bluetooth related configuration properties. |
-| [ethernet](#core-property-ethernet) | `object` [Ethernet](#ethernet-object) | Optional | Read-only | Ethernet related configuration properties. |
-| [id](#core-property-id) | `string` | Required | Read-only | The globally unique id of the thing. |
-| [latitude](#core-property-latitude) | `number` \| `null` | Required | Writable | The latitude the thing is installed at. |
-| [location](#core-property-location) | `string` \| `null` | Required | Writable | The name of the location the thing is installed at. |
-| [locationType](#core-property-locationType) | `string` \| `null` | Required | Writable | The type of location the thing is installed at. |
-| [longitude](#core-property-longitude) | `number` \| `null` | Required | Writable | The longitude the thing is installed at. |
-| [monitored](#core-property-monitored) | `string` \| `null` | Required | Writable | The identifier of the monitored object. |
-| [monitoredModel](#core-property-monitoredmodel) | `string` \| `null` | Required | Writable | The commercial model name of the monitored object. |
-| [monitoredType](#core-property-monitoredtype) | `string` \| `null` | Required | Writable | The type of the monitored object. |
-| [mqtt](#core-property-mqtt) | `object` [MQTT](#mqtt-object) | Optional | Read-only | MQTT related configuration properties. |
-| [name](#core-property-name) | `string` \| `null` | Required | Writable | A name identifying the thing inside an organization. |
-| [organization](#core-property-organization) | `string` \| `null` | Required | Writable | The name of the organization the thing is part of. |
-| [project](#core-property-project) | `string` \| `null` | Required | Writable | The name of the project the thing is part of. |
-| [sensors](#core-property-sensors) | `array` of `object` [Sensor](#sensor-object) | Optional | Read-only | A list of installed sensors. |
-| [site](#core-property-site) | `string` \| `null` | Required | Writable | The name of the site the thing is installed at. |
-| [system](#core-property-system) | `object` [System](#system-object) | Required | Read-only | Contains system wide settings. |
-| [wifi](#core-property-wifi) | `object` [WiFi](#wifi-object) | Optional | Read-only | WiFi related configuration properties. |
+| Property | Type | Min | Max | Existence | Mutablity | Description |
+|-|-|-|-|-|-|-|
+| [ais](#core-property-ais) | `array` of `object` [AI](#ai-object) | | | Optional | Read-only | A list of installed AI's. |
+| [bluetooth](#core-property-bluetooth) | `object` [Bluetooth](#bluetooth-object) | | | Optional | Read-only | Bluetooth related configuration properties. |
+| [ethernet](#core-property-ethernet) | `object` [Ethernet](#ethernet-object) | | | Optional | Read-only | Ethernet related configuration properties. |
+| [id](#core-property-id) | `string` | 5 | 5 | Required | Read-only | The globally unique id of the thing. |
+| [latitude](#core-property-latitude) | `number` \| `null` | -90.0 | 90.0 | Required | Writable | The latitude the thing is installed at. |
+| [location](#core-property-location) | `string` \| `null` | 1 | 200 | Required | Writable | The name of the location the thing is installed at. |
+| [locationType](#core-property-locationType) | `string` \| `null` | 1 | 200 | Required | Writable | The type of location the thing is installed at. |
+| [longitude](#core-property-longitude) | `number` \| `null` | -180.0 | 180.0 | Required | Writable | The longitude the thing is installed at. |
+| [monitored](#core-property-monitored) | `string` \| `null` | 1 | 200 | Required | Writable | The identifier of the monitored object. |
+| [monitoredModel](#core-property-monitoredmodel) | `string` \| `null` | 1 | 200 | Required | Writable | The commercial model name of the monitored object. |
+| [monitoredType](#core-property-monitoredtype) | `string` \| `null` | 1 | 200 | Required | Writable | The type of the monitored object. |
+| [mqtt](#core-property-mqtt) | `object` [MQTT](#mqtt-object) | | | Optional | Read-only | MQTT related configuration properties. |
+| [name](#core-property-name) | `string` \| `null` | 1 | 200 | Required | Writable | A name identifying the thing inside an organization. |
+| [organization](#core-property-organization) | `string` \| `null` | 1 | 200 | Required | Writable | The name of the organization the thing is part of. |
+| [project](#core-property-project) | `string` \| `null` | 1 | 200 | Required | Writable | The name of the project the thing is part of. |
+| [sensors](#core-property-sensors) | `array` of `object` [Sensor](#sensor-object) | | | Optional | Read-only | A list of installed sensors. |
+| [site](#core-property-site) | `string` \| `null` | 1 | 200 | Required | Writable | The name of the site the thing is installed at. |
+| [system](#core-property-system) | `object` [System](#system-object) | | | Required | Read-only | Contains system wide settings. |
+| [wifi](#core-property-wifi) | `object` [WiFi](#wifi-object) | | | Optional | Read-only | WiFi related configuration properties. |
 
 ### Core property `ais`
 
@@ -86,7 +86,7 @@ Existence: Required
 Mutability: Writable  
 Constraints:  
 
-- Must have a value between -90 and 90
+- Must have a value between -90.0 and 90.0
 
 ### Core property `location`
 
@@ -121,7 +121,7 @@ Existence: Required
 Mutability: Writable  
 Constraints:  
 
-- Must have a value between -180 and 180
+- Must have a value between -180.0 and 180.0
 
 ### Core property `monitored`
 
@@ -255,12 +255,12 @@ Constraints:
 
 Configuration properties for an AI.
 
-| Property | Type | Existence | Mutablity | Description |
-|-|-|-|-|-|
-| [model](#ai-property-model) | `string` | Required | Read-only | The commercial model name of the AI. |
-| [slot](#ai-property-slot) | `integer` | Required | Read-only | The slot the AI is installed in. |
-| [training](#ai-property-training) | `integer` | Required | Read-only | A number which denotes a series of cohesive AI trainings. |
-| [version](#ai-property-version) | `integer` | Required | Read-only | An AI training version number which starts at 1 and is increased by 1 each time a new training of that AI was done. |
+| Property | Type | Min | Max | Existence | Mutablity | Description |
+|-|-|-|-|-|-|-|
+| [model](#ai-property-model) | `string` | 1 | 200 | Required | Read-only | The commercial model name of the AI. |
+| [slot](#ai-property-slot) | `integer` | 0 | UINT8_MAX | Required | Read-only | The slot the AI is installed in. |
+| [training](#ai-property-training) | `integer` | 0 | UINT32_MAX | Required | Read-only | A number which denotes a series of cohesive AI trainings. |
+| [version](#ai-property-version) | `integer` | 0 | UINT32_MAX |Required | Read-only | An AI training version number which starts at 1 and is increased by 1 each time a new training of that AI was done. |
 
 ### AI property `model`
 
@@ -311,9 +311,9 @@ Constraints:
 
 Configuration properties for Bluetooth.
 
-| Property | Type | Existence | Mutablity | Description |
-|-|-|-|-|-|
-| [address](#bluetooth-property-address) | `string` | Required | Read-only | The identifier unique to every bluetooth thing. |
+| Property | Type | Min | Max | Existence | Mutablity | Description |
+|-|-|-|-|-|-|-|
+| [address](#bluetooth-property-address) | `string` | 17 | 17 | Required | Read-only | The identifier unique to every bluetooth thing. |
 
 ### Bluetooth property `address`
 
@@ -330,10 +330,10 @@ Constraints:
 
 Configuration properties for Ethernet.
 
-| Property | Type | Existence | Mutablity | Description |
-|-|-|-|-|-|
-| [ip](#ethernet-property-ip) | `string` \| `null` | Required | Read-only | The IP address assigned to the thing. |
-| [mac](#ethernet-property-mac) | `string` | Required | Read-only | The MAC address of the Ethernet interface. |
+| Property | Type | Min | Max | Existence | Mutablity | Description |
+|-|-|-|-|-|-|-|
+| [ip](#ethernet-property-ip) | `string` \| `null` | 7 | 15 | Required | Read-only | The IP address assigned to the thing. |
+| [mac](#ethernet-property-mac) | `string` | 17 | 17 | Required | Read-only | The MAC address of the Ethernet interface. |
 
 ### Ethernet property `ip`
 
@@ -344,7 +344,8 @@ Existence: Required
 Mutability: Read-only  
 Constraints:  
 
-- Must have a length of exactly 15 characters
+- Must have a length of at least 7 characters
+- Must have a length of at most 15 characters
 
 ### Ethernet property `mac`
 
@@ -361,13 +362,13 @@ Constraints:
 
 Configuration properties for MQTT.
 
-| Property | Type | Existence | Mutablity | Description |
-|-|-|-|-|-|
-| [host](#mqtt-property-host) | `string` \| `null` | Required | Writable | The IP address or DNS resolvable network name of an MQTT broker. |
-| [messages](#mqtt-property-messages) | `array` of `object` [MQTT message](#mqtt-message-object) | Required | Read-only | A list of MQTT messages that the thing either sends or receives. |
-| [password](#mqtt-property-password) | `string` \| `null` | Required | Writable | The MQTT broker password. |
-| [port](#mqtt-property-port) | `integer` \| `null` | Required | Writable | The MQTT broker port. |
-| [username](#mqtt-property-username) | `integer` \| `null` | Required | Writable | The MQTT broker username. |
+| Property | Type | Min | Max | Existence | Mutablity | Description |
+|-|-|-|-|-|-|-|
+| [host](#mqtt-property-host) | `string` \| `null` | 1 | 200 | Required | Writable | The IP address or DNS resolvable network name of an MQTT broker. |
+| [messages](#mqtt-property-messages) | `array` of `object` [MQTT message](#mqtt-message-object) | | | Required | Read-only | A list of MQTT messages that the thing either sends or receives. |
+| [password](#mqtt-property-password) | `string` \| `null` | 1 | 200 |Required | Writable | The MQTT broker password. |
+| [port](#mqtt-property-port) | `integer` \| `null` | 1 | UINT16_MAX | Required | Writable | The MQTT broker port. |
+| [username](#mqtt-property-username) | `string` \| `null` | 1 | 200 | Required | Writable | The MQTT broker username. |
 
 ### MQTT property `host`
 
@@ -409,7 +410,7 @@ Constraints:
 
 The MQTT broker username.  
 
-Type: `integer` | `null`  
+Type: `string` | `null`  
 Existence: Required  
 Mutability: Writable  
 Constraints:  
@@ -422,12 +423,12 @@ Constraints:
 
 Configuration properties for MQTT messages.
 
-| Property | Type | Existence | Mutablity | Description |
-|-|-|-|-|-|
-| [hasPayload](#mqtt-message-property-haspayload) | `boolean` | Required | Read-only | If the MQTT message has a payload. |
-| [name](#mqtt-message-property-name) | `string` | Required | Read-only | An identifying name of the MQTT message. |
-| [topic](#mqtt-message-property-topic) | `string` | Required | Read-only | The topic of the message. |
-| [toThing](#mqtt-message-property-tothing) | `boolean` | Required | Read-only | If the MQTT message is being sent to the thing. |
+| Property | Type | Min | Max | Existence | Mutablity | Description |
+|-|-|-|-|-|-|-|
+| [hasPayload](#mqtt-message-property-haspayload) | `boolean` | | | Required | Read-only | If the MQTT message has a payload. |
+| [name](#mqtt-message-property-name) | `string` | 1 | 30 | Required | Read-only | An identifying name of the MQTT message. |
+| [topic](#mqtt-message-property-topic) | `string` | 1 | 200 | Required | Read-only | The topic of the message. |
+| [toThing](#mqtt-message-property-tothing) | `boolean` | | | Required | Read-only | If the MQTT message is being sent to the thing. |
 
 ### MQTT property `hasPayload`
 
@@ -473,12 +474,11 @@ Mutability: Read-only
 
 Configuration properties for a sensor.
 
-| Property | Type | Existence | Mutablity | Description |
-|-|-|-|-|-|
-executed. |
-| [model](#sensor-property-model) | `string` | Required | Read-only | The commercial model name of the sensor. |
-| [port](#sensor-property-port) | `integer` | Required | Read-only | The number of the port the sensor is connected to. |
-| [type](#sensor-property-type) | `string` | Required | Read-only | The type of the sensor. |
+| Property | Type | Min | Max | Existence | Mutablity | Description |
+|-|-|-|-|-|-|-|
+| [model](#sensor-property-model) | `string` | 1 | 200 | Required | Read-only | The commercial model name of the sensor. |
+| [port](#sensor-property-port) | `integer` | 0 | UIN8_MAX | Required | Read-only | The number of the port the sensor is connected to. |
+| [type](#sensor-property-type) | `string` | 1 | 200 | Required | Read-only | The type of the sensor. |
 
 ### Sensor property `model`
 
@@ -519,15 +519,15 @@ Constraints:
 
 Contains system wide settings.
 
-| Property | Type | Existence | Mutablity | Description |
-|-|-|-|-|-|
-| [country](#system-property-country) | `string` | Required | Writable | The ISO 3166-1 alpha-2 country code the thing is operated in. |
-| [firmware](#system-property-firmware) | `string` | Required | Read-only | The commercial name of a firmware. |
-| [firmwareVersion](#system-property-firmwareversion) | `string` | Required | Read-only | The installed version of the firmware. |
-| [modelName](#system-property-modelname) | `string` | Required | Read-only | The model name of the WWT device. |
-| [modelNumber](#system-property-modelnumber) | `string` | Required | Read-only | The model number of the WWT device. |
-| [serialNumber](#system-property-serialnumber) | `string` | Required | Read-only | The serial number of the WWT device. |
-| [vendor](#system-property-vendor) | `string` | Required | Read-only | The name of the WWT device vendor. |
+| Property | Type | Min | Max | Existence | Mutablity | Description |
+|-|-|-|-|-|-|-|
+| [country](#system-property-country) | `string` | 2 | 2 | Required | Writable | The ISO 3166-1 alpha-2 country code the thing is operated in. |
+| [firmware](#system-property-firmware) | `string` | 1 | 200 |Required | Read-only | The commercial name of a firmware. |
+| [firmwareVersion](#system-property-firmwareversion) | `string` | 5 | 20 | Required | Read-only | The installed version of the firmware. |
+| [modelName](#system-property-modelname) | `string` | 1 | 200 | Required | Read-only | The model name of the WWT device. |
+| [modelNumber](#system-property-modelnumber) | `string` | 1 | 200 |Required | Read-only | The model number of the WWT device. |
+| [serialNumber](#system-property-serialnumber) | `string` | 1 | 200 | Required | Read-only | The serial number of the WWT device. |
+| [vendor](#system-property-vendor) | `string` | 1 | 200 | Required | Read-only | The name of the WWT device vendor. |
 
 ### System property `country`
 
@@ -618,12 +618,12 @@ Constraints:
 
 Configuration properties for WiFi.
 
-| Property | Type | Existence | Mutablity | Description |
-|-|-|-|-|-|
-| [ip](#wifi-property-ip) | `string` \| `null` | Required | Read-only | The IP address assigned to the thing. |
-| [mac](#wifi-property-mac) | `string` | Required | Read-only | The MAC address of the WiFi interface. |
-| [password](#wifi-property-password) | `string` \| `null` | Required | Writable | The password of the WiFi the thing will connect to. |
-| [ssid](#wifi-property-ssid) | `string` \| `null` | Required | Writable | The SSID of the WiFi the thing will connect to. |
+| Property | Type | Min | Max | Existence | Mutablity | Description |
+|-|-|-|-|-|-|-|
+| [ip](#wifi-property-ip) | `string` \| `null` | 7 | 15 |Required | Read-only | The IP address assigned to the thing. |
+| [mac](#wifi-property-mac) | `string` | 17 | 17 | Required | Read-only | The MAC address of the WiFi interface. |
+| [password](#wifi-property-password) | `string` \| `null` | 1 | 63 | Required | Writable | The password of the WiFi the thing will connect to. |
+| [ssid](#wifi-property-ssid) | `string` \| `null` | 1 | 32 |Required | Writable | The SSID of the WiFi the thing will connect to. |
 
 ### WiFi property `ip`
 
@@ -634,7 +634,8 @@ Existence: Required
 Mutability: Read-only  
 Constraints:  
 
-- Must have a length of exactly 15 characters
+- Must have a length of at least 7 characters
+- Must have a length of at most 15 characters
 
 ### WiFi property `mac`
 

--- a/Configuration.md
+++ b/Configuration.md
@@ -17,12 +17,13 @@ The core properties available in the root object.
 | [latitude](#core-property-latitude) | `number` \| `null` | Required | Writable | The latitude the thing is installed at. |
 | [location](#core-property-location) | `string` \| `null` | Required | Writable | The name of the location the thing is installed at. |
 | [locationType](#core-property-locationType) | `string` \| `null` | Required | Writable | The type of location the thing is installed at. |
-| [longitude](#core-property-longitude) | `number` \| `null` | Optional | Writable | The longitude the thing is installed at. |
+| [longitude](#core-property-longitude) | `number` \| `null` | Required | Writable | The longitude the thing is installed at. |
 | [monitored](#core-property-monitored) | `string` \| `null` | Required | Writable | The identifier of the monitored object. |
 | [monitoredModel](#core-property-monitoredmodel) | `string` \| `null` | Required | Writable | The commercial model name of the monitored object. |
 | [monitoredType](#core-property-monitoredtype) | `string` \| `null` | Required | Writable | The type of the monitored object. |
 | [mqtt](#core-property-mqtt) | `object` [MQTT](#mqtt-object) | Optional | Read-only | MQTT related configuration properties. |
 | [name](#core-property-name) | `string` \| `null` | Required | Writable | A name identifying the thing inside an organization. |
+| [organization](#core-property-organization) | `string` \| `null` | Required | Writable | The name of the organization the thing is part of. |
 | [project](#core-property-project) | `string` \| `null` | Required | Writable | The name of the project the thing is part of. |
 | [sensors](#core-property-sensors) | `array` of `object` [Sensor](#sensor-object) | Optional | Read-only | A list of installed sensors. |
 | [site](#core-property-site) | `string` \| `null` | Required | Writable | The name of the site the thing is installed at. |
@@ -111,6 +112,17 @@ Constraints:
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
+### Core property `longitude`
+
+The longitude the thing is installed at.
+
+Type: `number` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a value between -180 and 180
+
 ### Core property `monitored`
 
 The identifier of the monitored object.
@@ -162,6 +174,19 @@ Constraints:
 ### Core property `name`
 
 A name identifying the thing inside an organization.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+
+### Core property `organization`
+
+The name of the organization the thing is part of.
 
 Type: `string` | `null`
 Existence: Required
@@ -453,7 +478,7 @@ Configuration properties for a sensor.
 |-|-|-|-|-|
 executed. |
 | [model](#sensor-property-model) | `string` | Required | Read-only | The commercial model name of the sensor. |
-| [slot](#sensor-property-slot) | `integer` | Required | Read-only | The number of the slot the sensor is connected to. |
+| [port](#sensor-property-port) | `integer` | Required | Read-only | The number of the port the sensor is connected to. |
 | [type](#sensor-property-type) | `string` | Required | Read-only | The type of the sensor. |
 
 ### Sensor property `model`
@@ -468,9 +493,9 @@ Constraints:
 - Must have a length of at least 1 characters
 - Must have a length of at most 200 characters
 
-### Sensor property `slot`
+### Sensor property `port`
 
-The number of the slot the sensor is connected to.
+The number of the port the sensor is connected to.
 
 Type: `integer`
 Existence: Required

--- a/Configuration.md
+++ b/Configuration.md
@@ -521,7 +521,7 @@ Contains system wide settings.
 
 | Property | Type | Existence | Mutablity | Description |
 |-|-|-|-|-|
-| [country](#system-property-country) | `string` | Required | Writable | The ISO 3361-1 alpha-2 country code the thing is operated in. |
+| [country](#system-property-country) | `string` | Required | Writable | The ISO 3166-1 alpha-2 country code the thing is operated in. |
 | [firmware](#system-property-firmware) | `string` | Required | Read-only | The commercial name of a firmware. |
 | [firmwareVersion](#system-property-firmwareversion) | `string` | Required | Read-only | The installed version of the firmware. |
 | [modelName](#system-property-modelname) | `string` | Required | Read-only | The model name of the WWT device. |
@@ -531,7 +531,7 @@ Contains system wide settings.
 
 ### System property `country`
 
-The ISO 3361-1 alpha-2 country code the thing is operated in.  
+The ISO 3166-1 alpha-2 country code the thing is operated in.  
 
 Type: `string`  
 Existence: Required  
@@ -539,7 +539,7 @@ Mutability: Writable
 Constraints:  
 
 - Must consist of two letters
-- Must be one of the [ISO 3361-1 alpha-2 country code](https://www.iso.org/obp/ui)
+- Must be one of the [ISO 3166-1 alpha-2 country code](https://www.iso.org/obp/ui#iso:std:iso:3166:-1:ed-4:v1:en) / [ISO 3166-1 @ wikipedia.org](https://en.wikipedia.org/wiki/ISO_3166-1)
 
 ### System property `firmware`
 

--- a/Configuration.md
+++ b/Configuration.md
@@ -1,0 +1,598 @@
+# Configuration standards
+
+IoT things have different configuration properties like an identifier, a MAC address or the MQTT broker address. Some of them are writable, others are read-only. This specification aims to standardize their names and possible values.
+
+The type of each property is defined in regard to the [JSON Schema](https://json-schema.org) standard and its seven [data types](https://json-schema.org/draft/2020-12/json-schema-validation.html#name-type) which are `array`, `boolean`, `integer`, `object`, `null`, `number` or `string`.
+
+## Core object
+
+The core properties available in the root object.
+
+| Property | Type | Existence | Mutablity | Description |
+|-|-|-|-|-|
+| [ais](#core-property-ais) | `array` of `object` [AI](#ai-object) | Optional | Read-only | A list of installed AI's. |
+| [bluetooth](#core-property-bluetooth) | `object` [Bluetooth](#bluetooth-object) | Optional | Read-only | Bluetooth related configuration properties. |
+| [ethernet](#core-property-ethernet) | `object` [Ethernet](#ethernet-object) | Optional | Read-only | Ethernet related configuration properties. |
+| [id](#core-property-id) | `string` | Required | Read-only | The globally unique id of the thing. |
+| [latitude](#core-property-latitude) | `number` \| `null` | Required | Writable | The latitude the thing is installed at. |
+| [location](#core-property-location) | `string` \| `null` | Required | Writable | The name of the location the thing is installed at. |
+| [locationType](#core-property-locationType) | `string` \| `null` | Required | Writable | The type of location the thing is installed at. |
+| [longitude](#core-property-longitude) | `number` \| `null` | Optional | Writable | The longitude the thing is installed at. |
+| [monitored](#core-property-monitored) | `string` \| `null` | Required | Writable | The identifier of the monitored object. |
+| [monitoredModel](#core-property-monitoredmodel) | `string` \| `null` | Required | Writable | The commercial model name of the monitored object. |
+| [monitoredType](#core-property-monitoredtype) | `string` \| `null` | Required | Writable | The type of the monitored object. |
+| [mqtt](#core-property-mqtt) | `object` [MQTT](#mqtt-object) | Optional | Read-only | MQTT related configuration properties. |
+| [name](#core-property-name) | `string` \| `null` | Required | Writable | A name identifying the thing inside an organization. |
+| [project](#core-property-project) | `string` \| `null` | Required | Writable | The name of the project the thing is part of. |
+| [sensors](#core-property-sensors) | `array` of `object` [Sensor](#sensor-object) | Optional | Read-only | A list of installed sensors. |
+| [site](#core-property-site) | `string` \| `null` | Required | Writable | The name of the site the thing is installed at. |
+| [system](#core-property-system) | `object` [System](#system-object) | Required | Read-only | Contains system wide settings. |
+| [wifi](#core-property-wifi) | `object` [WiFi](#wifi-object) | Optional | Read-only | WiFi related configuration properties. |
+
+### Core property `ais`
+
+A list of installed AI's.
+
+Type: `array` of `object` [AI](#ai-object)
+Existence: Optional
+Mutability: Read-only
+Constraints:
+
+- Must not be present if empty
+- Must not be null
+
+### Core property `bluetooth`
+
+Bluetooth related configuration properties.
+
+Type: `object` [Bluetooth](#bluetooth-object)
+Existence: Optional
+Mutability: Read-only
+Constraints:
+
+- Must not be present if the thing does not support Bluetooth
+- Must be present if the thing supports Bluetooth
+
+### Core property `ethernet`
+
+Ethernet related configuration properties.
+
+Type: `object` [Ethernet](#ethernet-object)
+Existence: Optional
+Mutability: Read-only
+Constraints:
+
+- Must not be present if the thing does not support Ethernet
+- Must be present if the thing supports Ethernet
+
+### Core property `id`
+
+The globally unique id of the thing.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of exactly 5 characters
+
+### Core property `latitude`
+
+The latitude the thing is installed at.
+
+Type: `number` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a value between -90 and 90
+
+### Core property `location`
+
+The name of the location the thing is installed at.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### Core property `locationType`
+
+The type of location the thing is installed at.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### Core property `monitored`
+
+The identifier of the monitored object.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### Core property `monitoredModel`
+
+The commercial model name of the monitored object.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### Core property `monitoredType`
+
+The type of the monitored object.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### Core property `mqtt`
+
+MQTT related configuration properties.
+
+Type: `object` [MQTT](#mqtt-object)
+Existence: Optional
+Mutability: Read-only
+Constraints:
+
+- Must not be present if the thing does not support MQTT
+- Must be present if the thing supports MQTT
+
+### Core property `name`
+
+A name identifying the thing inside an organization.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### Core property `project`
+
+The name of the project the thing is part of.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### Core property `sensors`
+
+A list of installed sensors.
+
+Type: `array` of `object` [Sensor](#sensor-object)
+Existence: Optional
+Mutability: Read-only
+Constraints:
+
+- Must not be present if empty
+- Must not be null
+
+### Core property `site`
+
+The name of the site the thing is installed at.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### Core property `system`
+
+Contains system wide settings.
+
+Type: `object` [System](#system-object)
+Existence: Required
+Mutability: Read-only
+
+### Core property `wifi`
+
+WiFi related configuration properties.
+
+Type: `object` [WiFi](#wifi-object)
+Existence: Optional
+Mutability: Read-only
+Constraints:
+
+- Must not be present if the thing does not support WiFi
+- Must be present if the thing supports WiFi
+
+## AI object
+
+Configuration properties for an AI.
+
+| Property | Type | Existence | Mutablity | Description |
+|-|-|-|-|-|
+| [model](#ai-property-model) | `string` | Required | Read-only | The commercial model name of the AI. |
+| [slot](#ai-property-slot) | `integer` | Required | Read-only | The slot the AI is installed in. |
+| [training](#ai-property-training) | `integer` | Required | Read-only | A number which denotes a series of cohesive AI trainings. |
+| [version](#ai-property-version) | `integer` | Required | Read-only | An AI training version number which starts at 1 and is increased by 1 each time a new training of that AI was done. |
+
+### AI property `model`
+
+The commercial model name of the AI.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### AI property `slot`
+
+The slot the AI is installed in.
+
+Type: `integer`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must be an unsigned 8 bit integer
+
+### AI property `training`
+
+A number which denotes a series of cohesive AI trainings. It needs to be unique regarding the system of numbers it resides in.
+
+Type: `number`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must be an unsigned 32 bit integer
+
+### AI property `version`
+
+An AI training version number which starts at 1 and is increased by 1 each time a new training of that AI was done.
+
+Type: `integer`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must be an unsigned 32 bit integer
+
+## Bluetooth object
+
+Configuration properties for Bluetooth.
+
+| Property | Type | Existence | Mutablity | Description |
+|-|-|-|-|-|
+| [address](#bluetooth-property-address) | `string` | Required | Read-only | The identifier unique to every bluetooth thing. |
+
+### Bluetooth property `address`
+
+The identifier unique to every bluetooth thing.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of exactly 17 characters
+
+## Ethernet object
+
+Configuration properties for Ethernet.
+
+| Property | Type | Existence | Mutablity | Description |
+|-|-|-|-|-|
+| [ip](#ethernet-property-ip) | `string` \| `null` | Required | Read-only | The IP address assigned to the thing. |
+| [mac](#ethernet-property-mac) | `string` | Required | Read-only | The MAC address of the Ethernet interface. |
+
+### Ethernet property `ip`
+
+The IP address assigned to the thing.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of exactly 15 characters
+
+### Ethernet property `mac`
+
+The MAC address of the Ethernet interface.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of exactly 17 characters
+
+## MQTT object
+
+Configuration properties for MQTT.
+
+| Property | Type | Existence | Mutablity | Description |
+|-|-|-|-|-|
+| [host](#mqtt-property-host) | `string` \| `null` | Required | Writable | The IP address or DNS resolvable network name of an MQTT broker. |
+| [messages](#mqtt-property-messages) | `array` of `object` [MQTT message](#mqtt-message-object) | Required | Read-only | A list of MQTT messages that the thing either sends or receives. |
+| [password](#mqtt-property-password) | `string` \| `null` | Required | Writable | The MQTT broker password. |
+| [port](#mqtt-property-port) | `integer` \| `null` | Required | Writable | The MQTT broker port. |
+| [username](#mqtt-property-username) | `integer` \| `null` | Required | Writable | The MQTT broker username. |
+
+### MQTT property `host`
+
+The IP address or DNS resolvable network name of an MQTT broker.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### MQTT property `password`
+
+The MQTT broker password.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+- Must be `null` if not set
+
+### MQTT property `port`
+
+The MQTT broker port.
+
+Type: `integer` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must be an unsigned 16 bit integer
+
+### MQTT property `username`
+
+The MQTT broker username.
+
+Type: `integer` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+- Must be `null` if not set
+
+## MQTT message object
+
+Configuration properties for MQTT messages.
+
+| Property | Type | Existence | Mutablity | Description |
+|-|-|-|-|-|
+| [hasPayload](#mqtt-message-property-haspayload) | `boolean` | Required | Read-only | If the MQTT message has a payload. |
+| [name](#mqtt-message-property-name) | `string` | Required | Read-only | An identifying name of the MQTT message. |
+| [topic](#mqtt-message-property-topic) | `string` | Required | Read-only | The topic of the message. |
+| [toThing](#mqtt-message-property-tothing) | `boolean` | Required | Read-only | If the MQTT message is being sent to the thing. |
+
+### MQTT property `hasPayload`
+
+If the MQTT message has a payload.
+
+Type: `boolean`
+Existence: Required
+Mutability: Read-only
+
+### MQTT property `name`
+
+An identifying name of the MQTT message.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 30 characters
+
+### MQTT property `topic`
+
+The topic of the message.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### MQTT property `toThing`
+
+If the MQTT message is being sent to the thing.
+
+Type: `boolean`
+Existence: Required
+Mutability: Read-only
+
+## Sensor object
+
+Configuration properties for a sensor.
+
+| Property | Type | Existence | Mutablity | Description |
+|-|-|-|-|-|
+executed. |
+| [model](#sensor-property-model) | `string` | Required | Read-only | The commercial model name of the sensor. |
+| [slot](#sensor-property-slot) | `integer` | Required | Read-only | The number of the slot the sensor is connected to. |
+| [type](#sensor-property-type) | `string` | Required | Read-only | The type of the sensor. |
+
+### Sensor property `model`
+
+The commercial model name of the sensor.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+### Sensor property `slot`
+
+The number of the slot the sensor is connected to.
+
+Type: `integer`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must be an unsigned 8 bit integer
+
+### Sensor property `type`
+
+The type of the sensor.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 200 characters
+
+## System object
+
+Contains system wide settings.
+
+| Property | Type | Existence | Mutablity | Description |
+|-|-|-|-|-|
+| [country](#core-property-country) | `string` | Required | Writable | The ISO 3361-1 alpha-2 country code the thing is operated in. |
+| [firmware](#core-property-firmware) | `string` | Required | Read-only | The commercial name of a firmware. |
+| [firmwareVersion](#core-property-firmwareversion) | `string` | Required | Read-only | The installed version of the firmware. |
+
+### System property `country`
+
+The ISO 3361-1 alpha-2 country code the thing is operated in.
+
+Type: `string`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must consist of two letters
+- Must be one of the [ISO 3361-1 alpha-2 country code](https://www.iso.org/obp/ui)
+
+### System property `firmware`
+
+The commercial name of a firmware.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of at least 1 character
+- Must have a length of at most 200 characters
+
+### System property `firmwareVersion`
+
+The installed version of the firmware.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must adhere to the [semantic versioning](https://semver.org)
+- Must have a length of at least 5 characters
+- Must have a length of at most 20 characters
+
+## WiFi object
+
+Configuration properties for WiFi.
+
+| Property | Type | Existence | Mutablity | Description |
+|-|-|-|-|-|
+| [ip](#wifi-property-ip) | `string` \| `null` | Required | Read-only | The IP address assigned to the thing. |
+| [mac](#wifi-property-mac) | `string` | Required | Read-only | The MAC address of the WiFi interface. |
+| [password](#wifi-property-password) | `string` \| `null` | Required | Writable | The password of the WiFi the thing will connect to. |
+| [ssid](#wifi-property-ssid) | `string` \| `null` | Required | Writable | The SSID of the WiFi the thing will connect to. |
+
+### WiFi property `ip`
+
+The IP address assigned to the thing.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of exactly 15 characters
+
+### WiFi property `mac`
+
+The MAC address of the WiFi interface.
+
+Type: `string`
+Existence: Required
+Mutability: Read-only
+Constraints:
+
+- Must have a length of exactly 17 characters
+
+### WiFi property `password`
+
+The password of the WiFi the thing will connect to.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 63 characters
+- Must be `null` if not set
+
+### WiFi property `ssid`
+
+The SSID of the WiFi the thing will connect to.
+
+Type: `string` | `null`
+Existence: Required
+Mutability: Writable
+Constraints:
+
+- Must have a length of at least 1 characters
+- Must have a length of at most 32 characters
+- Must be `null` if not set

--- a/Configuration.md
+++ b/Configuration.md
@@ -521,61 +521,13 @@ Contains system wide settings.
 
 | Property | Type | Existence | Mutablity | Description |
 |-|-|-|-|-|
-| [vendor](#system-property-vendor) | `string` | Required | Read-only | The name of the WWT device vendor. |
-| [modelName](#system-property-modelname) | `string` | Required | Read-only | The model name of the WWT device. |
-| [modelNumber](#system-property-modelnumber) | `string` | Required | Read-only | The model number of the WWT device. |
-| [serialNumber](#system-property-serialnumber) | `string` | Required | Read-only | The serial number of the WWT device. |
 | [country](#system-property-country) | `string` | Required | Writable | The ISO 3361-1 alpha-2 country code the thing is operated in. |
 | [firmware](#system-property-firmware) | `string` | Required | Read-only | The commercial name of a firmware. |
 | [firmwareVersion](#system-property-firmwareversion) | `string` | Required | Read-only | The installed version of the firmware. |
-
-### System property `vendor`
-
-The name of the WWT device vendor.
-
-Type: `string`  
-Existence: Required  
-Mutability: Read-only  
-Constraints:  
-
-- Must have a length of at least 1 character
-- Must have a length of at most 200 characters
-
-### System property `modelName`
-
- The model name of the WWT device.
-
-Type: `string`  
-Existence: Required  
-Mutability: Read-only  
-Constraints:  
-
-- Must have a length of at least 1 character
-- Must have a length of at most 200 characters
-
-### System property `modelNumber`
-
-The model number of the WWT device.
-
-Type: `string`  
-Existence: Required  
-Mutability: Read-only  
-Constraints:  
-
-- Must have a length of at least 1 character
-- Must have a length of at most 200 characters
-
-### System property `serialNumber`
-
-The serial number of the WWT device.
-
-Type: `string`  
-Existence: Required  
-Mutability: Read-only  
-Constraints:  
-
-- Must have a length of at least 1 character
-- Must have a length of at most 200 characters
+| [modelName](#system-property-modelname) | `string` | Required | Read-only | The model name of the WWT device. |
+| [modelNumber](#system-property-modelnumber) | `string` | Required | Read-only | The model number of the WWT device. |
+| [serialNumber](#system-property-serialnumber) | `string` | Required | Read-only | The serial number of the WWT device. |
+| [vendor](#system-property-vendor) | `string` | Required | Read-only | The name of the WWT device vendor. |
 
 ### System property `country`
 
@@ -613,6 +565,54 @@ Constraints:
 - Must adhere to the [semantic versioning](https://semver.org)
 - Must have a length of at least 5 characters
 - Must have a length of at most 20 characters
+
+### System property `modelName`
+
+ The model name of the WWT device.
+
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
+
+- Must have a length of at least 1 character
+- Must have a length of at most 200 characters
+
+### System property `modelNumber`
+
+The model number of the WWT device.
+
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
+
+- Must have a length of at least 1 character
+- Must have a length of at most 200 characters
+
+### System property `serialNumber`
+
+The serial number of the WWT device.
+
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
+
+- Must have a length of at least 1 character
+- Must have a length of at most 200 characters
+
+### System property `vendor`
+
+The name of the WWT device vendor.
+
+Type: `string`  
+Existence: Required  
+Mutability: Read-only  
+Constraints:  
+
+- Must have a length of at least 1 character
+- Must have a length of at most 200 characters
 
 ## WiFi object
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# WWT device standards
+
+This repository defines standards for IoT devices. The goal to make them compatible to each other.
+
+Standards are defined in the following categories. Click on the links for the standard specifications.
+
+- [Configuration](Configuration.md)


### PR DESCRIPTION
Solution:
- to improve readabilty of value limits, add them to the property overview tables. numeric limits are given with reference to used data type as the limits are given as C integer limit macros.
- fix wrong data type of property descriptions
- fix reference of country codes and add some more describing references